### PR TITLE
Fixed RMT initialization on GPIO0

### DIFF
--- a/components/FastLED-idf/platforms/esp/32/clockless_rmt_esp32.cpp
+++ b/components/FastLED-idf/platforms/esp/32/clockless_rmt_esp32.cpp
@@ -276,13 +276,13 @@ void ESP32RMTController::init()
         // NOTE: In ESP-IDF 4.1++, there is a #define to init, but that doesn't exist
         // in earlier versions
 #if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(4, 1, 0)
-        rmt_config_t rmt_tx = RMT_DEFAULT_CONFIG_TX(gpio_num_t(mPin), rmt_channel);
+        rmt_config_t rmt_tx = RMT_DEFAULT_CONFIG_TX(mPin, rmt_channel);
 #else
         rmt_config_t rmt_tx;
         memset((void*) &rmt_tx, 0, sizeof(rmt_tx));
         rmt_tx.channel = rmt_channel;
         rmt_tx.rmt_mode = RMT_MODE_TX;
-        rmt_tx.gpio_num = gpio_num_t(mPin);
+        rmt_tx.gpio_num = mPin;
 #endif
 
         rmt_tx.mem_block_num = MEM_BLOCK_NUM; 

--- a/components/FastLED-idf/platforms/esp/32/clockless_rmt_esp32.cpp
+++ b/components/FastLED-idf/platforms/esp/32/clockless_rmt_esp32.cpp
@@ -276,13 +276,13 @@ void ESP32RMTController::init()
         // NOTE: In ESP-IDF 4.1++, there is a #define to init, but that doesn't exist
         // in earlier versions
 #if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(4, 1, 0)
-        rmt_config_t rmt_tx = RMT_DEFAULT_CONFIG_TX(gpio_num_t(0), rmt_channel);
+        rmt_config_t rmt_tx = RMT_DEFAULT_CONFIG_TX(gpio_num_t(mPin), rmt_channel);
 #else
         rmt_config_t rmt_tx;
         memset((void*) &rmt_tx, 0, sizeof(rmt_tx));
         rmt_tx.channel = rmt_channel;
         rmt_tx.rmt_mode = RMT_MODE_TX;
-        rmt_tx.gpio_num = gpio_num_t(0);  // The particular pin will be assigned later
+        rmt_tx.gpio_num = gpio_num_t(mPin);
 #endif
 
         rmt_tx.mem_block_num = MEM_BLOCK_NUM; 

--- a/components/FastLED-idf/platforms/esp/32/clockless_rmt_esp32.h
+++ b/components/FastLED-idf/platforms/esp/32/clockless_rmt_esp32.h
@@ -248,7 +248,7 @@ public:
 
     // -- Initialize RMT subsystem
     //    This only needs to be done once
-    static void init();
+    void init();
 
     // -- Show this string of pixels
     //    This is the main entry point for the pixel controller


### PR DESCRIPTION
This PR should solve issues #22 & #19.

Initially, I had issues with the coexistence of RMI Ethernet and FastLED-idf RMT, but with the help from @Pacheu and his writeup in issue #19 I was able to fix the issue. 

I simply updated the init function to initialize the RMT on the pin defined by the user and not statically using GPIO0.
